### PR TITLE
Specify branch in backend image build workflow

### DIFF
--- a/.github/workflows/build-backend-image.yml
+++ b/.github/workflows/build-backend-image.yml
@@ -1,6 +1,9 @@
 name: Backend Image build
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   buildImage:


### PR DESCRIPTION
Only build backend when code is merged to `master` branch.